### PR TITLE
fix: replace link_to with button_to for restore actions to fix routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-08-06
+
+### Fixed
+- **Restore Action Routing**: Fixed routing error where restore actions were generating GET requests instead of PATCH requests
+- **View Components**: Replaced `link_to` with `method: :patch` with proper `button_to` elements for restore actions
+
 ### Changed
 - **CI Optimization**: Moved RuboCop to separate lint job to avoid redundant execution across matrix builds
 - **Timeout Reduction**: Reduced Rails server startup timeout from 30s to 10s in CI tests
@@ -76,5 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bootstrap**: 5.3.0 (loaded via CDN)
 - **Bootstrap Icons**: 1.10.0 (loaded via CDN)
 
-[Unreleased]: https://github.com/your-org/paper_trail_history/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/your-org/paper_trail_history/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/your-org/paper_trail_history/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/your-org/paper_trail_history/releases/tag/v0.1.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paper_trail_history (0.1.0)
+    paper_trail_history (0.1.1)
       paper_trail (>= 15.0)
       rails (>= 7.2)
 

--- a/app/views/paper_trail_history/shared/_versions_table.html.erb
+++ b/app/views/paper_trail_history/shared/_versions_table.html.erb
@@ -43,7 +43,7 @@
             <div class="btn-group btn-group-sm">
               <%= link_to "View", version_path(decorated_version.version.id), class: "btn btn-outline-primary btn-sm" %>
               <% if decorated_version.can_restore? %>
-                <%= link_to "Restore", 
+                <%= button_to "Restore", 
                     restore_version_path(decorated_version.version.id), 
                     method: :patch,
                     data: { 

--- a/app/views/paper_trail_history/versions/show.html.erb
+++ b/app/views/paper_trail_history/versions/show.html.erb
@@ -10,7 +10,7 @@
   <h1>Version Details</h1>
   <div>
     <% if @decorated_version.can_restore? %>
-      <%= link_to "Restore This Version", 
+      <%= button_to "Restore This Version", 
           restore_version_path(@version), 
           method: :patch,
           data: { 
@@ -68,7 +68,7 @@
             This will restore the record to the state it was in at this version.
             <strong>This action cannot be undone</strong>, but will create a new version entry.
           </p>
-          <%= link_to "Restore This Version", 
+          <%= button_to "Restore This Version", 
               restore_version_path(@version), 
               method: :patch,
               data: { 

--- a/lib/paper_trail_history/version.rb
+++ b/lib/paper_trail_history/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PaperTrailHistory
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
- Fixed routing error where restore actions generated GET instead of PATCH requests
- Replaced link_to with method: :patch with proper button_to elements
- Updated both versions table and version show views
- Bumped version to 0.1.1

🤖 Generated with [Claude Code](https://claude.ai/code)