### PR TITLE
Fix version links for multi-database PaperTrail setups (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-12-16
+
+### Fixed
+- **Multi-Database Support**: Fixed version links in multi-database PaperTrail setups by adding optional `model_name` query parameter to ensure correct version table lookup and prevent issues with version ID collisions across different version tables
+
 ## [0.2.0] - 2025-12-04
 
 ### Changed
@@ -115,7 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bootstrap**: 5.3.0 (loaded via CDN)
 - **Bootstrap Icons**: 1.10.0 (loaded via CDN)
 
-[Unreleased]: https://github.com/your-org/paper_trail_history/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/your-org/paper_trail_history/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/your-org/paper_trail_history/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/your-org/paper_trail_history/compare/v0.1.3...v0.2.0
 [0.1.3]: https://github.com/your-org/paper_trail_history/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/your-org/paper_trail_history/compare/v0.1.1...v0.1.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paper_trail_history (0.2.0)
+    paper_trail_history (0.2.1)
       paper_trail (>= 15.0)
       rails (>= 8.0)
 
@@ -84,29 +84,29 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
-    bigdecimal (3.3.1)
+    bigdecimal (4.0.0)
     builder (3.3.0)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.5)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     crass (1.0.6)
-    date (3.5.0)
+    date (3.5.1)
     drb (2.2.3)
-    erb (6.0.0)
+    erb (6.0.1)
     erubi (1.13.1)
     globalid (1.3.0)
       activesupport (>= 6.1)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
-    io-console (0.8.1)
+    io-console (0.8.2)
     irb (1.15.3)
       pp (>= 0.6.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.17.0)
+    json (2.18.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.24.1)
+    loofah (2.25.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -117,8 +117,8 @@ GEM
       net-smtp
     marcel (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.26.2)
-    net-imap (0.5.12)
+    minitest (5.27.0)
+    net-imap (0.6.0)
       date
       net-protocol
     net-pop (0.1.2)
@@ -159,7 +159,7 @@ GEM
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack
-    psych (5.2.6)
+    psych (5.3.0)
       date
       stringio
     puma (7.1.0)
@@ -171,7 +171,7 @@ GEM
       rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
     rails (8.1.1)
       actioncable (= 8.1.1)
@@ -205,7 +205,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.1)
-    rdoc (6.16.1)
+    rdoc (6.17.0)
       erb
       psych (>= 4.0.0)
       tsort
@@ -246,7 +246,7 @@ GEM
     sqlite3 (2.8.1-x86_64-linux-musl)
     stringio (3.1.9)
     thor (1.4.0)
-    timeout (0.4.4)
+    timeout (0.5.0)
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -259,7 +259,7 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.7.3)
+    zeitwerk (2.7.4)
 
 PLATFORMS
   aarch64-linux-gnu
@@ -293,29 +293,29 @@ CHECKSUMS
   activesupport (8.1.1) sha256=5e92534e8d0c8b8b5e6b16789c69dbea65c1d7b752269f71a39422e9546cea67
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
-  bigdecimal (3.3.1) sha256=eaa01e228be54c4f9f53bf3cc34fe3d5e845c31963e7fcc5bedb05a4e7d52218
+  bigdecimal (4.0.0) sha256=ec797dffef5566eeccf9f1a39df8fc78ef9c39158dc85b2036d5f11c7e0d3b86
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
-  concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
-  date (3.5.0) sha256=5e74fd6c04b0e65d97ad4f3bb5cb2d8efb37f386cc848f46310b4593ffc46ee5
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
-  erb (6.0.0) sha256=2730893f9d8c9733f16cab315a4e4b71c1afa9cabc1a1e7ad1403feba8f52579
+  erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
   i18n (1.14.7) sha256=ceba573f8138ff2c0915427f1fc5bdf4aa3ab8ae88c8ce255eb3ecf0a11a5d0f
-  io-console (0.8.1) sha256=1e15440a6b2f67b6ea496df7c474ed62c860ad11237f29b3bd187f054b925fcb
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.15.3) sha256=4349edff1efa7ff7bfd34cb9df74a133a588ba88c2718098b3b4468b81184aaa
-  json (2.17.0) sha256=90895466df75c53f0c7ddbae5748bcdf4f908d9d6485242cf4c647f6c3d788b1
+  json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  loofah (2.24.1) sha256=655a30842b70ec476410b347ab1cd2a5b92da46a19044357bbd9f401b009a337
+  loofah (2.25.0) sha256=df5ed7ac3bac6a4ec802df3877ee5cc86d027299f8952e6243b3dac446b060e6
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (5.26.2) sha256=f021118a6185b9ba9f5af71f2ba103ad770c75afde9f2ab8da512677c550cde3
-  net-imap (0.5.12) sha256=cb8cd05bd353fcc19b6cbc530a9cb06b577a969ea10b7ddb0f37787f74be4444
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  net-imap (0.6.0) sha256=5d48bb048c85addcf0d83f6ff55be02aea111437c21d1cf3adf62b2fbe0f6cc8
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
@@ -329,27 +329,27 @@ CHECKSUMS
   nokogiri (1.18.10-x86_64-linux-gnu) sha256=ff5ba26ba2dbce5c04b9ea200777fd225061d7a3930548806f31db907e500f72
   nokogiri (1.18.10-x86_64-linux-musl) sha256=0651fccf8c2ebbc2475c8b1dfd7ccac3a0a6d09f8a41b72db8c21808cb483385
   paper_trail (17.0.0) sha256=1c2842061d3874ca7015908e821e2aa14f9b982af2acb2a7974713bf79021c85
-  paper_trail_history (0.2.0)
+  paper_trail_history (0.2.1)
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.0) sha256=ce3587fa5cc55a88c4ba5b2b37621b3329aadf5728f9eafa36bbd121462aabd6
   pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.6.0) sha256=bfc0281a81718c4872346bc858dc84abd3a60cae78336c65ad35c8fbff641c6b
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
-  psych (5.2.6) sha256=814328aa5dcb6d604d32126a20bc1cbcf05521a5b49dbb1a8b30a07e580f316e
+  psych (5.3.0) sha256=8976a41ae29ea38c88356e862629345290347e3bfe27caf654f7c5a920e95eeb
   puma (7.1.0) sha256=e45c10cb124f224d448c98db653a75499794edbecadc440ad616cf50f2fd49dd
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.4) sha256=5d74b6f75082a643f43c1e76b419c40f0e5527fcfee1e669ac1e6b73c0ccb6f6
   rack-session (2.1.1) sha256=0b6dc07dea7e4b583f58a48e8b806d4c9f1c6c9214ebc202ec94562cbea2e4e9
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
-  rackup (2.2.1) sha256=f737191fd5c5b348b7f0a4412a3b86383f88c43e13b8217b63d4c8d90b9e798d
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.1.1) sha256=877509b7aef309239978685883097d2c03e21383a50a3f78882cf9b3b5c136f7
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.6.2) sha256=35fce2ca8242da8775c83b6ba9c1bcaad6751d9eb73c1abaa8403475ab89a560
   railties (8.1.1) sha256=fb0c7038b147bea41bf6697fa443ff1c5c47d3bb1eedd9ecf1bceeb90efcb868
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
-  rdoc (6.16.1) sha256=71357cc208e6da77ba0c4494e01ae870dd18b437c7c7d801dd73ee2f340b9f5c
+  rdoc (6.17.0) sha256=0f50d4e568fc98195f9bb155a9e8dff6c7feabfb515fb22ef6df1d12ad5a02b7
   regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
   reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
   request_store (1.7.0) sha256=e1b75d5346a315f452242a68c937ef8e48b215b9453a77a6c0acdca2934c88cb
@@ -368,7 +368,7 @@ CHECKSUMS
   sqlite3 (2.8.1-x86_64-linux-musl) sha256=0c191ddfd71437b439e107a0d148630bef29a1eebd7b28bcc931470c328f657d
   stringio (3.1.9) sha256=c111af13d3a73eab96a3bc2655ecf93788d13d28cb8e25c1dcbff89ace885121
   thor (1.4.0) sha256=8763e822ccb0f1d7bee88cde131b19a65606657b847cc7b7b4b82e772bcd8a3d
-  timeout (0.4.4) sha256=f0f6f970104b82427cd990680f539b6bbb8b1e55efa913a55c6492935e4e0edb
+  timeout (0.5.0) sha256=852aefd13f41d84c2d0d83099b275034c6517395884b58e635acc8847c9190cb
   tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
@@ -377,7 +377,7 @@ CHECKSUMS
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
-  zeitwerk (2.7.3) sha256=b2e86b4a9b57d26ba68a15230dcc7fe6f040f06831ce64417b0621ad96ba3e85
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
 
 BUNDLED WITH
   4.0.0

--- a/app/controllers/paper_trail_history/versions_controller.rb
+++ b/app/controllers/paper_trail_history/versions_controller.rb
@@ -14,9 +14,9 @@ module PaperTrailHistory
       result = VersionService.restore_version(@version.id)
 
       if result[:success]
-        redirect_back_or_to(version_path(@version), notice: result[:message])
+        redirect_back_or_to(version_path(@version, model_name: @version.item_type), notice: result[:message])
       else
-        redirect_back_or_to(version_path(@version),
+        redirect_back_or_to(version_path(@version, model_name: @version.item_type),
                             alert: t('paper_trail_history.errors.restore_failed', error: result[:error]))
       end
     end
@@ -24,8 +24,10 @@ module PaperTrailHistory
     private
 
     def find_version
-      @version = PaperTrail::Version.find(params[:id])
-    rescue ActiveRecord::RecordNotFound
+      @version = VersionService.find_version(params[:id], params[:model_name])
+
+      return if @version
+
       redirect_to root_path, alert: t('paper_trail_history.errors.version_not_found')
     end
   end

--- a/app/helpers/paper_trail_history/application_helper.rb
+++ b/app/helpers/paper_trail_history/application_helper.rb
@@ -3,5 +3,16 @@
 module PaperTrailHistory
   # Helper module providing utility methods for PaperTrailHistory views
   module ApplicationHelper
+    # Generate version path with model_name context when available
+    def version_link_path(version, options = {})
+      model_name = options[:model_name] || version.item_type
+      version_path(version.id, model_name: model_name)
+    end
+
+    # Generate restore version path with model_name context
+    def restore_version_link_path(version, options = {})
+      model_name = options[:model_name] || version.item_type
+      restore_version_path(version.id, model_name: model_name)
+    end
   end
 end

--- a/app/models/paper_trail_history/version_service.rb
+++ b/app/models/paper_trail_history/version_service.rb
@@ -19,6 +19,19 @@ module PaperTrailHistory
       apply_record_filters(versions, params).order(created_at: :desc)
     end
 
+    def self.find_version(version_id, model_name = nil)
+      if model_name.present?
+        # Direct query when model_name is known (fast)
+        trackable_model = TrackableModel.find(model_name)
+        return nil unless trackable_model
+
+        trackable_model.version_class.unscoped.find_by(id: version_id)
+      else
+        # Fall back to searching across all tables (backwards compatible)
+        find_version_across_tables(version_id)
+      end
+    end
+
     def self.restore_version(version_id)
       version = find_version_across_tables(version_id)
       return validate_version_for_restore(version) unless version_restorable?(version)

--- a/app/views/paper_trail_history/shared/_versions_table.html.erb
+++ b/app/views/paper_trail_history/shared/_versions_table.html.erb
@@ -16,8 +16,8 @@
       <% versions.each do |decorated_version| %>
         <tr>
           <td>
-            <%= link_to "##{decorated_version.version.id}", 
-                version_path(decorated_version.version.id), 
+            <%= link_to "##{decorated_version.version.id}",
+                version_link_path(decorated_version.version),
                 class: "text-decoration-none" %>
           </td>
           <td>
@@ -41,13 +41,13 @@
           <% end %>
           <td>
             <div class="btn-group btn-group-sm">
-              <%= link_to "View", version_path(decorated_version.version.id), class: "btn btn-outline-primary btn-sm" %>
+              <%= link_to "View", version_link_path(decorated_version.version), class: "btn btn-outline-primary btn-sm" %>
               <% if decorated_version.can_restore? %>
-                <%= button_to "Restore", 
-                    restore_version_path(decorated_version.version.id), 
+                <%= button_to "Restore",
+                    restore_version_link_path(decorated_version.version),
                     method: :patch,
-                    data: { 
-                      confirm: "Are you sure you want to restore this version?" 
+                    data: {
+                      confirm: "Are you sure you want to restore this version?"
                     },
                     class: "btn btn-outline-warning btn-sm" %>
               <% end %>

--- a/app/views/paper_trail_history/versions/show.html.erb
+++ b/app/views/paper_trail_history/versions/show.html.erb
@@ -10,11 +10,11 @@
   <h1>Version Details</h1>
   <div>
     <% if @decorated_version.can_restore? %>
-      <%= button_to "Restore This Version", 
-          restore_version_path(@version), 
+      <%= button_to "Restore This Version",
+          restore_version_link_path(@version),
           method: :patch,
-          data: { 
-            confirm: "Are you sure you want to restore this version? This will overwrite the current data." 
+          data: {
+            confirm: "Are you sure you want to restore this version? This will overwrite the current data."
           },
           class: "btn btn-warning" %>
     <% end %>
@@ -68,11 +68,11 @@
             This will restore the record to the state it was in at this version.
             <strong>This action cannot be undone</strong>, but will create a new version entry.
           </p>
-          <%= button_to "Restore This Version", 
-              restore_version_path(@version), 
+          <%= button_to "Restore This Version",
+              restore_version_link_path(@version),
               method: :patch,
-              data: { 
-                confirm: "Are you sure you want to restore this version? This will overwrite the current data and cannot be undone." 
+              data: {
+                confirm: "Are you sure you want to restore this version? This will overwrite the current data and cannot be undone."
               },
               class: "btn btn-warning" %>
         </div>

--- a/lib/paper_trail_history/version.rb
+++ b/lib/paper_trail_history/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PaperTrailHistory
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/test/controllers/paper_trail_history/versions_controller_test.rb
+++ b/test/controllers/paper_trail_history/versions_controller_test.rb
@@ -21,6 +21,10 @@ module PaperTrailHistory
         'Users'
       end
 
+      def mock_model.version_class
+        PaperTrail::Version
+      end
+
       TrackableModel.stub :find, mock_model do
         get version_url(@version)
         assert_response :success
@@ -40,7 +44,7 @@ module PaperTrailHistory
 
       VersionService.stub :restore_version, result do
         patch restore_version_url(@version)
-        assert_redirected_to version_path(@version)
+        assert_redirected_to version_path(@version, model_name: @version.item_type)
         follow_redirect!
         assert_select '.alert-success'
       end
@@ -51,10 +55,55 @@ module PaperTrailHistory
 
       VersionService.stub :restore_version, result do
         patch restore_version_url(@version)
-        assert_redirected_to version_path(@version)
+        assert_redirected_to version_path(@version, model_name: @version.item_type)
         follow_redirect!
         assert_select '.alert-danger'
       end
+    end
+
+    test 'should get show with model_name parameter' do
+      mock_model = Object.new
+      def mock_model.name
+        'User'
+      end
+
+      def mock_model.human_name
+        'Users'
+      end
+
+      def mock_model.version_class
+        PaperTrail::Version
+      end
+
+      TrackableModel.stub :find, mock_model do
+        get version_url(@version, model_name: 'User')
+        assert_response :success
+        assert_select 'h1', 'Version Details'
+      end
+    end
+
+    test 'should get show without model_name parameter (backwards compatibility)' do
+      mock_model = Object.new
+      def mock_model.name
+        'User'
+      end
+
+      def mock_model.human_name
+        'Users'
+      end
+
+      TrackableModel.stub :find, mock_model do
+        get version_url(@version)
+        assert_response :success
+        assert_select 'h1', 'Version Details'
+      end
+    end
+
+    test 'redirects for version with invalid model_name' do
+      get version_url(@version, model_name: 'NonExistentModel')
+      assert_redirected_to root_path
+      follow_redirect!
+      assert_select '.alert-danger'
     end
 
     private

--- a/test/helpers/paper_trail_history/application_helper_test.rb
+++ b/test/helpers/paper_trail_history/application_helper_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module PaperTrailHistory
+  class ApplicationHelperTest < ActionView::TestCase
+    include Engine.routes.url_helpers
+
+    setup do
+      @version = create_test_version
+    end
+
+    test 'version_link_path includes model_name from version' do
+      path = version_link_path(@version)
+      assert_includes path, 'model_name=User'
+    end
+
+    test 'version_link_path accepts model_name option' do
+      path = version_link_path(@version, model_name: 'CustomModel')
+      assert_includes path, 'model_name=CustomModel'
+    end
+
+    test 'restore_version_link_path includes model_name from version' do
+      path = restore_version_link_path(@version)
+      assert_includes path, 'model_name=User'
+    end
+
+    test 'restore_version_link_path accepts model_name option' do
+      path = restore_version_link_path(@version, model_name: 'CustomModel')
+      assert_includes path, 'model_name=CustomModel'
+    end
+
+    private
+
+    def create_test_version(attributes = {})
+      PaperTrail::Version.create!({
+        item_type: 'User',
+        item_id: 1,
+        event: 'update',
+        whodunnit: 'test_user',
+        object: { name: 'old_name' }.to_yaml,
+        object_changes: { name: %w[old_name new_name] }.to_yaml,
+        created_at: Time.current
+      }.merge(attributes))
+    end
+  end
+end

--- a/test/models/paper_trail_history/version_service_test.rb
+++ b/test/models/paper_trail_history/version_service_test.rb
@@ -66,6 +66,35 @@ module PaperTrailHistory
       assert_includes result[:error], 'Cannot restore create events'
     end
 
+    test 'find_version with model_name uses specific version class' do
+      version = create_test_version
+      found = VersionService.find_version(version.id, 'User')
+
+      assert_not_nil found
+      assert_equal version.id, found.id
+    end
+
+    test 'find_version without model_name searches across tables' do
+      version = create_test_version
+      found = VersionService.find_version(version.id)
+
+      assert_not_nil found
+      assert_equal version.id, found.id
+    end
+
+    test 'find_version with invalid model_name returns nil' do
+      version = create_test_version
+      found = VersionService.find_version(version.id, 'NonExistentModel')
+
+      assert_nil found
+    end
+
+    test 'find_version with nil version_id returns nil' do
+      found = VersionService.find_version(99_999, 'User')
+
+      assert_nil found
+    end
+
     private
 
     def create_test_version(attributes = {})


### PR DESCRIPTION
## Summary

Fixes version links in multi-database PaperTrail setups where each model has its own version table. Version URLs now include an optional `model_name` query parameter that enables direct queries to the correct version table.

## Problem

When using multiple version tables (e.g., `ProductVersion` with `product_versions` table, `User` with `versions` table), version links like `/versions/107748` would fail because:
- The controller assumed a single `PaperTrail::Version` table
- Version IDs can collide across different tables (each has independent auto-incrementing sequences)

## Solution

Added optional `model_name` query parameter to version URLs:
- **With context**: `/versions/123?model_name=User` → direct query to specific table (fast)
- **Without context**: `/versions/123` → searches all tables (backwards compatible)

## Changes

- ✅ Added `VersionService.find_version` method with optional `model_name` parameter
- ✅ Updated `VersionsController` to use new lookup method
- ✅ Created helper methods for generating version URLs with model context
- ✅ Updated all views to use new helper methods
- ✅ Added comprehensive test coverage (11 new tests)
- ✅ All 56 tests passing
- ✅ RuboCop compliant

## Test Coverage

- `VersionService.find_version` with and without model_name
- Controller actions with model_name parameter
- Backwards compatibility (URLs without model_name)
- Invalid model_name handling
- Helper URL generation

## Backwards Compatibility

✅ **Fully backwards compatible** - existing URLs and bookmarks continue to work by falling back to cross-table search.

## Release Notes

Version bumped to **0.2.1** with changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 (1M context) <noreply@anthropic.com>